### PR TITLE
Looks like you accidentally had the wrong order of arguments for process.stdout.getWindowSize()

### DIFF
--- a/TermUI.coffee
+++ b/TermUI.coffee
@@ -45,9 +45,7 @@ module.exports = T = new class TermUI extends EventEmitter
   }
 
   handleSizeChange: =>
-    winsize = process.stdout.getWindowSize()
-    @width = winsize[1]
-    @height = winsize[0]
+    [ @width, @height ] = process.stdout.getWindowSize()
     @emit 'resize', {w: @width, h: @height}
 
   out: (buf) ->


### PR DESCRIPTION
Either that, or node changed their signature somewhere along the line. Anyways, this fixes the resize event.
