### PR TITLE
node v0.8

### DIFF
--- a/TermUI.coffee
+++ b/TermUI.coffee
@@ -1,3 +1,4 @@
+keypress = require 'keypress'
 util = require 'util'
 tty = require 'tty'
 {EventEmitter} = require 'events'
@@ -9,8 +10,9 @@ module.exports = T = new class TermUI extends EventEmitter
   constructor: ->
 
     if tty.isatty process.stdin
-      tty.setRawMode true
+      process.stdin.setRawMode true
       process.stdin.resume()
+      keypress process.stdin
 
       process.stdin.on 'keypress', @handleKeypress
       process.stdin.on 'data', @handleData
@@ -156,7 +158,7 @@ module.exports = T = new class TermUI extends EventEmitter
     @fg(@C.x).bg(@C.x)
     @disableMouse()
     @showCursor()
-    tty.setRawMode(false)
+    process.stdin.setRawMode false
     process.exit()
 
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "main": "TermUI.coffee",
   "dependencies": {
+    "keypress": "",
     "underscore": "",
     "underscore.string": ""
   },


### PR DESCRIPTION
Hi, I migrated your module to the node v0.8 API.

v0.8 removed the `keypress` event on `process.stdin` and you need to use the new `readline` module and parse out the pressed keys. Fortunately, the `keypress` package does this for us.

Cheers!
